### PR TITLE
NGA-374: remove code triggering Visioning rebuild

### DIFF
--- a/pp-infra/src/lambda/identify_unprocessed_grids/identify_unprocessed_grids.py
+++ b/pp-infra/src/lambda/identify_unprocessed_grids/identify_unprocessed_grids.py
@@ -61,7 +61,6 @@ def lambda_handler(event, context):
 
         unprocessed_products = [
             product for product in product_database.l3_src_products if product.id not in processed_product_ids
-            or ("Visioning" in product.name and "64" not in product.resolution)
         ]
 
         logging.info("Planning on processing {} products".format(


### PR DESCRIPTION
Removing a debug line that will cause Visioning Coral sea to be rebuilt all the time.